### PR TITLE
[FEATURE] Implement automatic dependency injection for configuration classes

### DIFF
--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "mteu/typo3-typed-extconf".
+ *
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+use mteu\TypedExtConf\Attribute\ExtensionConfig;
+use mteu\TypedExtConf\Provider\ExtensionConfigurationProvider;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+return static function (ContainerBuilder $container): void {
+    $container->registerAttributeForAutoconfiguration(
+        ExtensionConfig::class,
+        static function (
+            ChildDefinition $definition,
+            ExtensionConfig $attribute,
+            \ReflectionClass $reflector,
+        ): void {
+            $definition
+                ->setFactory([
+                    new Reference(ExtensionConfigurationProvider::class), 'get',
+                ])
+                ->setArguments([
+                    $reflector->name,
+                    $attribute->extensionKey,
+                ])
+            ;
+        }
+    );
+};

--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -59,9 +59,45 @@ final readonly class MyExtensionConfiguration
 }
 ```
 
-### Step 2: Inject and Use the Configuration Mapper
+### Step 2: Use Your Configuration
 
-Inject the configuration mapper service in your classes:
+#### Recommended: Direct Injection
+
+Simply inject your configuration class directly:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Vendor\MyExtension\Service;
+
+use Vendor\MyExtension\Configuration\MyExtensionConfiguration;
+
+final readonly class MyService
+{
+    public function __construct(
+        private MyExtensionConfiguration $config,
+    ) {}
+
+    public function doSomething(): void
+    {
+        // All properties are now properly typed
+        $maxItems = $this->config->maxItems; // int
+        $isEnabled = $this->config->enableFeature; // bool
+        $endpoint = $this->config->apiEndpoint; // string
+
+        // Use your configuration...
+        if ($isEnabled && $maxItems > 0) {
+            // Your business logic here
+        }
+    }
+}
+```
+
+#### Alternative: Using the Provider
+
+If you need more control, use the configuration provider:
 
 ```php
 <?php
@@ -82,16 +118,7 @@ final readonly class MyService
     public function doSomething(): void
     {
         $config = $this->extensionConfigurationProvider->get(MyExtensionConfiguration::class);
-
-        // All properties are now properly typed
-        $maxItems = $config->maxItems; // int
-        $isEnabled = $config->enableFeature; // bool
-        $endpoint = $config->apiEndpoint; // string
-
-        // Use your configuration...
-        if ($isEnabled && $maxItems > 0) {
-            // Your business logic here
-        }
+        // Use configuration...
     }
 }
 ```
@@ -229,8 +256,21 @@ final readonly class CacheConfiguration
 
 ### Dependency Injection
 
-The extension uses TYPO3's dependency injection system. Simply type-hint the
-`ExtensionConfigurationProvider` interface:
+The extension automatically registers your configuration classes as DI services. You can inject them directly:
+
+```php
+use Vendor\MyExtension\Configuration\MyExtensionConfiguration;
+
+final readonly class MyController
+{
+    public function __construct(
+        private MyExtensionConfiguration $config,
+        // ... other dependencies
+    ) {}
+}
+```
+
+Alternatively, inject the provider service if you need more control:
 
 ```php
 use mteu\TypedExtConf\Provider\ExtensionConfigurationProvider;
@@ -577,13 +617,3 @@ final readonly class MyConfiguration
     ) {}
 }
 ```
-
-## Conclusion
-
-The `mteu/typo3-typed-extconf` extension provides a powerful foundation for
-type-safe extension configuration in TYPO3 v13. By following this guide and the
-best practices outlined above, you can eliminate runtime errors caused by type
-mismatches and significantly improve your extension's developer experience.
-
-For additional support or to report issues, please visit the
-[project repository](https://github.com/mteu/typodrei).

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ expected types and default values
 type mapping and validation
 - **Default Handling**: Provide sensible defaults for missing configuration keys
 - **Path Mapping**: Support for nested configuration paths with dot notation
+- **Dependency Injection**: Configuration classes are automatically registered as DI services
 - **Developer Experience**: Simple API for accessing typed configuration values
 
 ## ⚡️ Installation
@@ -93,7 +94,33 @@ final readonly class MyExtensionConfig
 
 ### 2. Access Typed Configuration
 
-Inject the configuration service and access your typed configuration:
+#### Option A: Direct Injection (Recommended)
+
+Directly inject your configuration object using dependency injection:
+
+```php
+<?php
+
+final readonly class MyService
+{
+    public function __construct(
+        private MyExtensionConfig $config,
+    ) {}
+
+    public function doSomething(): void
+    {
+        // All properties are guaranteed to have the correct types
+        $maxItems = $this->config->maxItems; // int
+        $isEnabled = $this->config->enableFeature; // bool
+        $endpoint = $this->config->apiEndpoint; // string
+        $types = $this->config->allowedTypes; // array
+    }
+}
+```
+
+#### Option B: Using the Provider
+
+Alternatively, use the configuration provider service:
 
 ```php
 <?php
@@ -110,11 +137,7 @@ final readonly class MyService
     {
         $config = $this->extensionConfigurationProvider->get(MyExtensionConfig::class);
 
-        // All properties are guaranteed to have the correct types
-        $maxItems = $config->maxItems; // int
-        $isEnabled = $config->enableFeature; // bool
-        $endpoint = $config->apiEndpoint; // string
-        $types = $config->allowedTypes; // array
+        // Use configuration...
     }
 }
 ```

--- a/Tests/Unit/DependencyInjection/AutoconfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/AutoconfigurationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "mteu/typo3-typed-extconf".
+ *
+ * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace mteu\TypedExtConf\Tests\Unit\DependencyInjection;
+
+use mteu\TypedExtConf\Attribute\ExtensionConfig;
+use mteu\TypedExtConf\Provider\ExtensionConfigurationProvider;
+use mteu\TypedExtConf\Tests\Unit\Fixture\SimpleTestConfiguration;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ChildDefinition;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * AutoconfigurationTest.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+final class AutoconfigurationTest extends TestCase
+{
+    #[Test]
+    public function testAttributeAutoconfigurationRegistersService(): void
+    {
+        $container = new ContainerBuilder();
+
+        $configurator = require __DIR__ . '/../../../Configuration/Services.php';
+        assert(is_callable($configurator));
+        $configurator($container);
+
+        $reflectionClass = new \ReflectionClass(SimpleTestConfiguration::class);
+        $attribute = $reflectionClass->getAttributes(ExtensionConfig::class)[0]->newInstance();
+
+        $definition = new ChildDefinition('abstract.service');
+
+        $autoconfigurationCallbacks = $container->getAttributeAutoconfigurators();
+
+        self::assertArrayHasKey(ExtensionConfig::class, $autoconfigurationCallbacks);
+
+        $configurators = $autoconfigurationCallbacks[ExtensionConfig::class];
+        self::assertIsArray($configurators);
+
+        $callback = reset($configurators);
+        self::assertIsCallable($callback);
+
+        $callback($definition, $attribute, $reflectionClass);
+
+        $factory = $definition->getFactory();
+        self::assertIsArray($factory);
+        self::assertInstanceOf(Reference::class, $factory[0]);
+        self::assertSame(ExtensionConfigurationProvider::class, (string)$factory[0]);
+        self::assertSame('get', $factory[1]);
+
+        $arguments = $definition->getArguments();
+        self::assertCount(2, $arguments);
+        self::assertSame(SimpleTestConfiguration::class, $arguments[0]);
+        self::assertSame('test_ext', $arguments[1]);
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Parameter \#2 \$configurator of method Symfony\\Component\\DependencyInjection\\ContainerBuilder\:\:registerAttributeForAutoconfiguration\(\) expects callable\(Symfony\\Component\\DependencyInjection\\ChildDefinition, mteu\\TypedExtConf\\Attribute\\ExtensionConfig, Reflector\)\: void, Closure\(Symfony\\Component\\DependencyInjection\\ChildDefinition, mteu\\TypedExtConf\\Attribute\\ExtensionConfig, ReflectionClass\)\: void given\.$#'
+			identifier: argument.type
+			count: 1
+			path: Configuration/Services.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+	- phpstan-baseline.neon
+
 parameters:
 	paths:
 		- Classes


### PR DESCRIPTION
This PR implements automatic dependency injection for configuration classes, which should dramatically improve the developer experience. The new `Configuration/Services.php` holds attribute auto-configuration registering all `#[ExtensionConfig]` classes as DI services so you don't have to.

Thanks to @eliashaeussler who came up with the idea and prototyped the DI configuration. 💛 