### PR TITLE
[FEATURE] Allow injection of custom `TreeMapper` via DI

### DIFF
--- a/Classes/Mapper/TreeMapperFactory.php
+++ b/Classes/Mapper/TreeMapperFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the TYPO3 CMS extension "typed-extconf".
+ *
+ * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace mteu\TypedExtConf\Mapper;
+
+use CuyZ\Valinor\Mapper\TreeMapper;
+use CuyZ\Valinor\MapperBuilder;
+
+/**
+ * TreeMapperFactory.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-2.0-or-later
+ */
+final readonly class TreeMapperFactory
+{
+    public function create(): TreeMapper
+    {
+        return (new MapperBuilder())
+            ->allowSuperfluousKeys()
+            ->mapper();
+    }
+}

--- a/Classes/Provider/TypedExtensionConfigurationProvider.php
+++ b/Classes/Provider/TypedExtensionConfigurationProvider.php
@@ -25,7 +25,6 @@ namespace mteu\TypedExtConf\Provider;
 
 use CuyZ\Valinor\Mapper\MappingError;
 use CuyZ\Valinor\Mapper\TreeMapper;
-use CuyZ\Valinor\MapperBuilder;
 use mteu\TypedExtConf\Attribute\ExtConfProperty;
 use mteu\TypedExtConf\Attribute\ExtensionConfig;
 use mteu\TypedExtConf\Exception\ConfigurationException;
@@ -41,15 +40,10 @@ use TYPO3\CMS\Core\SingletonInterface;
  */
 final readonly class TypedExtensionConfigurationProvider implements ExtensionConfigurationProvider, SingletonInterface
 {
-    private TreeMapper $mapper;
-
     public function __construct(
         private ExtensionConfiguration $extensionConfiguration,
-    ) {
-        $this->mapper = (new MapperBuilder())
-            ->allowSuperfluousKeys()
-            ->mapper();
-    }
+        private TreeMapper $mapper,
+    ) {}
 
     /**
      * @template T of object

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "mteu/typo3-typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed-extconf".
  *
  * Copyright (C) 2025
  * Elias Häußler <elias@haeussler.dev>, Martin Adler <mteu@mailbox.org>

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "mteu/typo3-typed-extconf".
  *
- * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ * Copyright (C) 2025
+ * Elias Häußler <elias@haeussler.dev>, Martin Adler <mteu@mailbox.org>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +22,9 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+use CuyZ\Valinor\Mapper\TreeMapper;
 use mteu\TypedExtConf\Attribute\ExtensionConfig;
+use mteu\TypedExtConf\Mapper\TreeMapperFactory;
 use mteu\TypedExtConf\Provider\ExtensionConfigurationProvider;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -46,4 +49,14 @@ return static function (ContainerBuilder $container): void {
             ;
         }
     );
+
+    $container->register(TreeMapperFactory::class)
+        ->setAutowired(true)
+        ->setAutoconfigured(true);
+
+    $container->register(TreeMapper::class, TreeMapper::class)
+        ->setFactory([new Reference(TreeMapperFactory::class), 'create'])
+        ->setAutowired(true)
+        ->setAutoconfigured(true)
+        ->setPublic(false);
 };

--- a/Documentation/command-guide.md
+++ b/Documentation/command-guide.md
@@ -272,12 +272,12 @@ use Vendor\Extension\Configuration\MyExtensionConfiguration;
 final readonly class MyService
 {
     public function __construct(
-        private ExtensionConfigurationProvider $extensionConfigurationProvider,
+        private ExtensionConfigurationProvider $configurationProvider,
     ) {}
 
     public function getConfiguration(): MyExtensionConfiguration
     {
-        return $this->extensionConfigurationProvider->get(MyExtensionConfiguration::class);
+        return $this->configurationProvider->get(MyExtensionConfiguration::class);
     }
 }
 ```
@@ -401,7 +401,7 @@ $timeout = (int)($config['timeout'] ?? 30);
 
 **After**:
 ```php
-$config = $this->extensionConfigurationProvider->get(MyExtensionConfiguration::class);
+$config = $this->configurationProvider->get(MyExtensionConfiguration::class);
 $timeout = $config->timeout; // Already typed and with defaults
 ```
 
@@ -416,7 +416,7 @@ $enabled = (bool)($config['enabled'] ?? false);
 
 **After**:
 ```php
-$config = $this->extensionConfigurationProvider->get(MyExtensionConfiguration::class);
+$config = $this->configurationProvider->get(MyExtensionConfiguration::class);
 $enabled = $config->enabled; // Type-safe boolean
 ```
 

--- a/README.md
+++ b/README.md
@@ -130,12 +130,12 @@ use mteu\TypedExtConf\Provider\ExtensionConfigurationProvider;
 final readonly class MyService
 {
     public function __construct(
-        private ExtensionConfigurationProvider $extensionConfigurationProvider,
+        private ExtensionConfigurationProvider $configurationProvider,
     ) {}
 
     public function doSomething(): void
     {
-        $config = $this->extensionConfigurationProvider->get(MyExtensionConfig::class);
+        $config = $this->configurationProvider->get(MyExtensionConfig::class);
 
         // Use configuration...
     }

--- a/Tests/Unit/DependencyInjection/AutoconfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/AutoconfigurationTest.php
@@ -23,8 +23,10 @@ declare(strict_types=1);
 
 namespace mteu\TypedExtConf\Tests\Unit\DependencyInjection;
 
+use CuyZ\Valinor\Mapper\TreeMapper;
 use EliasHaeussler\PHPUnitAttributes\Attribute\RequiresPackage;
 use mteu\TypedExtConf\Attribute\ExtensionConfig;
+use mteu\TypedExtConf\Mapper\TreeMapperFactory;
 use mteu\TypedExtConf\Provider\ExtensionConfigurationProvider;
 use mteu\TypedExtConf\Tests\Unit\Fixture\SimpleTestConfiguration;
 use PHPUnit\Framework\Attributes\Test;
@@ -123,5 +125,47 @@ final class AutoconfigurationTest extends TestCase
         self::assertCount(2, $arguments);
         self::assertSame(SimpleTestConfiguration::class, $arguments[0]);
         self::assertSame('test_ext', $arguments[1]);
+    }
+
+    #[Test]
+    public function testTreeMapperFactoryRegistration(): void
+    {
+        $container = new ContainerBuilder();
+
+        $configurator = require __DIR__ . '/../../../Configuration/Services.php';
+        assert(is_callable($configurator));
+
+        $configurator($container);
+
+        self::assertTrue($container->hasDefinition(TreeMapperFactory::class));
+
+        $definition = $container->getDefinition(TreeMapperFactory::class);
+        self::assertTrue($definition->isAutowired());
+        self::assertTrue($definition->isAutoconfigured());
+    }
+
+    #[Test]
+    public function testTreeMapperRegistration(): void
+    {
+        $container = new ContainerBuilder();
+
+        $configurator = require __DIR__ . '/../../../Configuration/Services.php';
+        assert(is_callable($configurator));
+
+        $configurator($container);
+
+        self::assertTrue($container->hasDefinition(TreeMapper::class));
+
+        $definition = $container->getDefinition(TreeMapper::class);
+
+        $factory = $definition->getFactory();
+        self::assertIsArray($factory);
+        self::assertInstanceOf(Reference::class, $factory[0]);
+        self::assertSame(TreeMapperFactory::class, (string)$factory[0]);
+        self::assertSame('create', $factory[1]);
+
+        self::assertTrue($definition->isAutowired());
+        self::assertTrue($definition->isAutoconfigured());
+        self::assertFalse($definition->isPublic());
     }
 }

--- a/Tests/Unit/Provider/TypedExtensionConfigurationProviderTest.php
+++ b/Tests/Unit/Provider/TypedExtensionConfigurationProviderTest.php
@@ -59,7 +59,6 @@ final class TypedExtensionConfigurationProviderTest extends Framework\TestCase
     protected function setUp(): void
     {
         $this->extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
-        // @todo: test both automatic injection and custom mapper injection
         $this->subject = new TypedExtensionConfigurationProvider(
             $this->extensionConfiguration,
             (new MapperBuilder())

--- a/Tests/Unit/Provider/TypedExtensionConfigurationProviderTest.php
+++ b/Tests/Unit/Provider/TypedExtensionConfigurationProviderTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace mteu\TypedExtConf\Tests\Unit\Provider;
 
+use CuyZ\Valinor\MapperBuilder;
 use mteu\TypedExtConf\Exception\ConfigurationException;
 use mteu\TypedExtConf\Exception\SchemaValidationException;
 use mteu\TypedExtConf\Provider\TypedExtensionConfigurationProvider;
@@ -58,7 +59,13 @@ final class TypedExtensionConfigurationProviderTest extends Framework\TestCase
     protected function setUp(): void
     {
         $this->extensionConfiguration = $this->createMock(ExtensionConfiguration::class);
-        $this->subject = new TypedExtensionConfigurationProvider($this->extensionConfiguration);
+        // @todo: test both automatic injection and custom mapper injection
+        $this->subject = new TypedExtensionConfigurationProvider(
+            $this->extensionConfiguration,
+            (new MapperBuilder())
+                ->allowSuperfluousKeys()
+                ->mapper(),
+        );
     }
 
     #[Test]


### PR DESCRIPTION
This PR refactors `TypedExtensionConfigurationProvider` to allow injecting a custom `TreeMapper` instance via the constructor. 

Needs https://github.com/mteu/typo3-typed-extconf/pull/9 to be merged first.
Resolves https://github.com/mteu/typo3-typed-extconf/issues/10.