### PR TITLE
[FEATURE] Introduce generic `ConfigurationMapperFactory` interface

### DIFF
--- a/Classes/Mapper/MapperFactory.php
+++ b/Classes/Mapper/MapperFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /*
  * This file is part of the TYPO3 CMS extension "typed-extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -24,20 +24,14 @@ declare(strict_types=1);
 namespace mteu\TypedExtConf\Mapper;
 
 use CuyZ\Valinor\Mapper\TreeMapper;
-use CuyZ\Valinor\MapperBuilder;
 
 /**
- * TreeMapperFactory.
+ * MapperFactory.
  *
- * @author Martin Adler <mteu@mailbox.org>
+ * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-2.0-or-later
  */
-final readonly class TreeMapperFactory implements MapperFactory
+interface MapperFactory
 {
-    public function create(): TreeMapper
-    {
-        return (new MapperBuilder())
-            ->allowSuperfluousKeys()
-            ->mapper();
-    }
+    public function create(): TreeMapper;
 }

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 
 use CuyZ\Valinor\Mapper\TreeMapper;
 use mteu\TypedExtConf\Attribute\ExtensionConfig;
-use mteu\TypedExtConf\Mapper\TreeMapperFactory;
+use mteu\TypedExtConf\Mapper\MapperFactory;
 use mteu\TypedExtConf\Provider\ExtensionConfigurationProvider;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -51,5 +51,5 @@ return static function (ContainerBuilder $container): void {
     );
 
     $container->register(TreeMapper::class)
-        ->setFactory([new Reference(TreeMapperFactory::class), 'create']);
+        ->setFactory([new Reference(MapperFactory::class), 'create']);
 };

--- a/Tests/Unit/DependencyInjection/AutoconfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/AutoconfigurationTest.php
@@ -26,7 +26,7 @@ namespace mteu\TypedExtConf\Tests\Unit\DependencyInjection;
 use CuyZ\Valinor\Mapper\TreeMapper;
 use EliasHaeussler\PHPUnitAttributes\Attribute\RequiresPackage;
 use mteu\TypedExtConf\Attribute\ExtensionConfig;
-use mteu\TypedExtConf\Mapper\TreeMapperFactory;
+use mteu\TypedExtConf\Mapper\MapperFactory;
 use mteu\TypedExtConf\Provider\ExtensionConfigurationProvider;
 use mteu\TypedExtConf\Tests\Unit\Fixture\SimpleTestConfiguration;
 use PHPUnit\Framework\Attributes\Test;
@@ -144,7 +144,7 @@ final class AutoconfigurationTest extends TestCase
         $factory = $definition->getFactory();
         self::assertIsArray($factory);
         self::assertInstanceOf(Reference::class, $factory[0]);
-        self::assertSame(TreeMapperFactory::class, (string)$factory[0]);
+        self::assertSame(MapperFactory::class, (string)$factory[0]);
         self::assertSame('create', $factory[1]);
     }
 }


### PR DESCRIPTION
This PR introduces a new `MapperFactory` interface. With this interface, registration of custom configuration mappers is now easier, since the interface can be implemented and the implementing class can be registered as default mapper factory for use in the configuration providers.