### PR TITLE
[!!!][TASK] Remove optional extensionKey parameter from attribute

### DIFF
--- a/Classes/Attribute/ExtensionConfig.php
+++ b/Classes/Attribute/ExtensionConfig.php
@@ -33,6 +33,6 @@ namespace mteu\TypedExtConf\Attribute;
 final readonly class ExtensionConfig
 {
     public function __construct(
-        public ?string $extensionKey = null,
+        public string $extensionKey,
     ) {}
 }

--- a/Classes/Provider/ExtensionConfigurationProvider.php
+++ b/Classes/Provider/ExtensionConfigurationProvider.php
@@ -41,5 +41,5 @@ interface ExtensionConfigurationProvider
      * @throws ConfigurationException
      * @throws SchemaValidationException
      */
-    public function get(string $configClass, ?string $extensionKey = null): object;
+    public function get(string $configClass): object;
 }

--- a/Classes/Provider/TypedExtensionConfigurationProvider.php
+++ b/Classes/Provider/TypedExtensionConfigurationProvider.php
@@ -52,7 +52,7 @@ final readonly class TypedExtensionConfigurationProvider implements ExtensionCon
      * @throws ConfigurationException
      * @throws SchemaValidationException
      */
-    public function get(string $configClass, ?string $extensionKey = null): object
+    public function get(string $configClass): object
     {
         $reflection = new \ReflectionClass($configClass);
 
@@ -62,7 +62,7 @@ final readonly class TypedExtensionConfigurationProvider implements ExtensionCon
             );
         }
 
-        $extensionKey = $this->resolveExtensionKey($reflection, $extensionKey);
+        $extensionKey = $this->resolveExtensionKey($reflection);
         $rawConfig = $this->getRawConfiguration($extensionKey);
         $configData = $this->prepareConfigurationData($reflection, $rawConfig);
 
@@ -80,28 +80,18 @@ final readonly class TypedExtensionConfigurationProvider implements ExtensionCon
     /**
      * @param \ReflectionClass<object> $reflection
      */
-    private function resolveExtensionKey(\ReflectionClass $reflection, ?string $extensionKey): string
+    private function resolveExtensionKey(\ReflectionClass $reflection): string
     {
-        if ($extensionKey !== null) {
-            return $extensionKey;
-        }
-
         $extensionConfigAttributes = $reflection->getAttributes(ExtensionConfig::class);
 
         if ($extensionConfigAttributes === []) {
             throw new ConfigurationException(
-                sprintf('Configuration class "%s" must have an #[ExtensionConfig] attribute or extension key must be provided', $reflection->getName())
+                sprintf('Configuration class "%s" must have an #[ExtensionConfig] attribute', $reflection->getName())
             );
         }
 
         /** @var ExtensionConfig $extensionConfig */
         $extensionConfig = $extensionConfigAttributes[0]->newInstance();
-
-        if ($extensionConfig->extensionKey === null) {
-            throw new ConfigurationException(
-                sprintf('Extension key must be specified either via #[ExtensionConfig] attribute or method parameter')
-            );
-        }
 
         return $extensionConfig->extensionKey;
     }

--- a/Documentation/developer-guide.md
+++ b/Documentation/developer-guide.md
@@ -309,13 +309,13 @@ $provider = GeneralUtility::makeInstance(ExtensionConfigurationProvider::class);
 $config = $provider->get(MyConfiguration::class);
 ```
 
-### Override Extension Key
+### Configuration Access
 
-You can override the extension key at runtime:
+The configuration is accessed through the provider service:
 
 ```php
-// Use a different extension key than what's defined in the #[ExtensionConfig] attribute
-$config = $this->configurationProvider->get(MyConfiguration::class, 'other_extension');
+// Access configuration using the extension key defined in the #[ExtensionConfig] attribute
+$config = $this->configurationProvider->get(MyConfiguration::class);
 ```
 
 ### TreeMapper Configuration
@@ -446,7 +446,7 @@ final class MyExtensionConfigurationTest extends TestCase
                 'api' => ['endpoint' => '/api/v2'],
             ]);
 
-        $provider = new TypedExtensionConfigurationProvider($extensionConfiguration);
+        $provider = new TypedExtensionConfigurationProvider($extensionConfiguration, $mapper);
         $config = $provider->get(MyExtensionConfiguration::class);
 
         self::assertSame(50, $config->maxItems);
@@ -534,18 +534,15 @@ final readonly class MyConfiguration { /* ... */ }
 
 **Solution**: Ensure your TYPO3 configuration values can be converted to the expected types. Check your `ext_conf_template.txt` and backend configuration.
 
-#### 4. Null Extension Key
+#### 4. Missing Extension Key
 
-**Error**: `Extension key must be specified`
+**Error**: `Configuration class must have an #[ExtensionConfig] attribute`
 
-**Solution**: Either set the extension key in the attribute or pass it as a parameter:
+**Solution**: Add the required extension key in the attribute:
 
 ```php
-// Option 1: Set in attribute
 #[ExtensionConfig(extensionKey: 'my_extension')]
-
-// Option 2: Pass as parameter
-$config = $mapper->map(MyConfiguration::class, 'my_extension');
+final readonly class MyConfiguration { /* ... */ }
 ```
 
 ### Debugging Configuration

--- a/README.md
+++ b/README.md
@@ -147,8 +147,7 @@ Class-level attribute to specify which TYPO3 extension the configuration belongs
 to.
 
 **Parameters:**
-- `extensionKey` (string, optional): The TYPO3 extension key. If not provided,
-must be passed to the service method.
+- `extensionKey` (string, required): The TYPO3 extension key.
 
 ### `#[ExtConfProperty]`
 

--- a/Tests/Unit/Fixture/InvalidExtensionConfigTestConfiguration.php
+++ b/Tests/Unit/Fixture/InvalidExtensionConfigTestConfiguration.php
@@ -31,7 +31,7 @@ use mteu\TypedExtConf\Attribute\ExtensionConfig;
  * @author Martin Adler <mteu@mailbox.org>
  * @license GPL-2.0-or-later
  */
-#[ExtensionConfig(extensionKey: null)]
+// This class intentionally has no ExtensionConfig attribute to test error handling
 final readonly class InvalidExtensionConfigTestConfiguration
 {
     public function __construct(

--- a/Tests/Unit/Fixture/RequiredTestConfiguration.php
+++ b/Tests/Unit/Fixture/RequiredTestConfiguration.php
@@ -24,13 +24,17 @@ declare(strict_types=1);
 namespace mteu\TypedExtConf\Tests\Unit\Fixture;
 
 use mteu\TypedExtConf\Attribute\ExtConfProperty;
+use mteu\TypedExtConf\Attribute\ExtensionConfig;
 
 /**
  * RequiredTestConfiguration.
  *
  * @author Martin Adler <mteu@mailbox.org>
  * @license GPL-2.0-or-later
- */
+ *
+ * @phpstan-ignore symplify.requireAttributeName
+ **/
+#[ExtensionConfig('test_ext')]
 final readonly class RequiredTestConfiguration
 {
     public function __construct(

--- a/Tests/Unit/Provider/TypedExtensionConfigurationProviderTest.php
+++ b/Tests/Unit/Provider/TypedExtensionConfigurationProviderTest.php
@@ -232,22 +232,22 @@ final class TypedExtensionConfigurationProviderTest extends Framework\TestCase
     }
 
     #[Test]
-    public function testMapWithExplicitExtensionKey(): void
+    public function testMapUsesExtensionKeyFromAttribute(): void
     {
         $configData = [
             'basic' => [
-                'string' => 'explicit_key_test',
+                'string' => 'attribute_key_test',
             ],
         ];
 
         $this->extensionConfiguration->expects(self::once())
             ->method('get')
-            ->with('custom_key')
+            ->with('test_ext')
             ->willReturn($configData);
 
-        $result = $this->subject->get(SimpleTestConfiguration::class, 'custom_key');
+        $result = $this->subject->get(SimpleTestConfiguration::class);
 
-        self::assertSame('explicit_key_test', $result->stringValue);
+        self::assertSame('attribute_key_test', $result->stringValue);
     }
 
     #[Test]
@@ -261,10 +261,10 @@ final class TypedExtensionConfigurationProviderTest extends Framework\TestCase
 
         $this->extensionConfiguration->expects(self::once())
             ->method('get')
-            ->with('monitoring')
+            ->with('test_ext')
             ->willReturn($configData);
 
-        $result = $this->subject->get(RequiredTestConfiguration::class, 'monitoring');
+        $result = $this->subject->get(RequiredTestConfiguration::class);
 
         self::assertSame('present', $result->requiredValue);
         self::assertSame('optional', $result->optionalValue);
@@ -281,13 +281,13 @@ final class TypedExtensionConfigurationProviderTest extends Framework\TestCase
 
         $this->extensionConfiguration->expects(self::once())
             ->method('get')
-            ->with('monitoring')
+            ->with('test_ext')
             ->willReturn($configData);
 
         $this->expectException(ConfigurationException::class);
         $this->expectExceptionMessage('Required configuration key "required.value" is missing');
 
-        $this->subject->get(RequiredTestConfiguration::class, 'monitoring');
+        $this->subject->get(RequiredTestConfiguration::class);
     }
 
     #[Test]
@@ -309,7 +309,7 @@ final class TypedExtensionConfigurationProviderTest extends Framework\TestCase
     public function testMapNullExtensionKeyThrowsException(): void
     {
         $this->expectException(ConfigurationException::class);
-        $this->expectExceptionMessage('Extension key must be specified');
+        $this->expectExceptionMessage('must have an #[ExtensionConfig] attribute');
 
         $this->subject->get(InvalidExtensionConfigTestConfiguration::class);
     }


### PR DESCRIPTION
Remove optional extensionKey parameter from `get()` method in `ExtensionConfigurationProvider`. The extension key must now be specified in the #[ExtensionConfig] attribute.

```diff
interface ExtensionConfigurationProvider
{
-  public function get(string $configClass, ?string $extensionKey = null): object;
+  public function get(string $configClass): object;
// ..
}
```