### PR TITLE
[TASK] Rephrase license header according to TYPO3 coding standards

### DIFF
--- a/Classes/Attribute/ExtConfProperty.php
+++ b/Classes/Attribute/ExtConfProperty.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Attribute;

--- a/Classes/Attribute/ExtensionConfig.php
+++ b/Classes/Attribute/ExtensionConfig.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Attribute;

--- a/Classes/Command/GenerateConfigurationCommand.php
+++ b/Classes/Command/GenerateConfigurationCommand.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Command;

--- a/Classes/Exception/ConfigurationException.php
+++ b/Classes/Exception/ConfigurationException.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Exception;

--- a/Classes/Exception/SchemaValidationException.php
+++ b/Classes/Exception/SchemaValidationException.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Exception;

--- a/Classes/Generator/ConfigurationClassGenerator.php
+++ b/Classes/Generator/ConfigurationClassGenerator.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Generator;

--- a/Classes/Mapper/MapperFactory.php
+++ b/Classes/Mapper/MapperFactory.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Elias Häußler <elias@haeussler.dev>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Mapper;

--- a/Classes/Mapper/TreeMapperFactory.php
+++ b/Classes/Mapper/TreeMapperFactory.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Mapper;

--- a/Classes/Parser/ExtConfTemplateParser.php
+++ b/Classes/Parser/ExtConfTemplateParser.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Parser;

--- a/Classes/Provider/ExtensionConfigurationProvider.php
+++ b/Classes/Provider/ExtensionConfigurationProvider.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Provider;

--- a/Classes/Provider/TypedExtensionConfigurationProvider.php
+++ b/Classes/Provider/TypedExtensionConfigurationProvider.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Provider;

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -3,23 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025
- * Elias Häußler <elias@haeussler.dev>, Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 use mteu\TypedExtConf\Attribute\ExtensionConfig;

--- a/Tests/CGL/composer-dependency-analyser.php
+++ b/Tests/CGL/composer-dependency-analyser.php
@@ -3,23 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "type-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2021-2025
- * Elias Häußler <elias@haeussler.dev>, Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 use Composer\Autoload;

--- a/Tests/CGL/php-cs-fixer.php
+++ b/Tests/CGL/php-cs-fixer.php
@@ -2,7 +2,21 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 $config = \TYPO3\CodingStandards\CsFixerConfig::create();
+$config->setHeader('This file is part of the TYPO3 CMS extension "typed_extconf".');
 $config->setParallelConfig(\PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
 $config->getFinder()->in(dirname(__DIR__, 2));
 

--- a/Tests/CGL/rector.php
+++ b/Tests/CGL/rector.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 use Rector\Config\RectorConfig;
 
 return RectorConfig::configure()

--- a/Tests/Unit/Attribute/ExtConfPropertyTest.php
+++ b/Tests/Unit/Attribute/ExtConfPropertyTest.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Attribute;

--- a/Tests/Unit/DependencyInjection/AutoconfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/AutoconfigurationTest.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\DependencyInjection;

--- a/Tests/Unit/Fixture/Configuration/ApiConfiguration.php
+++ b/Tests/Unit/Fixture/Configuration/ApiConfiguration.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Fixture\Configuration;

--- a/Tests/Unit/Fixture/Configuration/ComplexTestConfiguration.php
+++ b/Tests/Unit/Fixture/Configuration/ComplexTestConfiguration.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Fixture\Configuration;

--- a/Tests/Unit/Fixture/Configuration/ErrorTestConfiguration.php
+++ b/Tests/Unit/Fixture/Configuration/ErrorTestConfiguration.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Fixture\Configuration;

--- a/Tests/Unit/Fixture/Configuration/InvalidExtensionConfigTestConfiguration.php
+++ b/Tests/Unit/Fixture/Configuration/InvalidExtensionConfigTestConfiguration.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Fixture\Configuration;

--- a/Tests/Unit/Fixture/Configuration/MultiNestedTestConfiguration.php
+++ b/Tests/Unit/Fixture/Configuration/MultiNestedTestConfiguration.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Fixture\Configuration;

--- a/Tests/Unit/Fixture/Configuration/NestedTestConfiguration.php
+++ b/Tests/Unit/Fixture/Configuration/NestedTestConfiguration.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Fixture\Configuration;

--- a/Tests/Unit/Fixture/Configuration/RequiredTestConfiguration.php
+++ b/Tests/Unit/Fixture/Configuration/RequiredTestConfiguration.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Fixture\Configuration;

--- a/Tests/Unit/Fixture/Configuration/SecurityConfiguration.php
+++ b/Tests/Unit/Fixture/Configuration/SecurityConfiguration.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Fixture\Configuration;

--- a/Tests/Unit/Fixture/Configuration/SimpleTestConfiguration.php
+++ b/Tests/Unit/Fixture/Configuration/SimpleTestConfiguration.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Fixture\Configuration;

--- a/Tests/Unit/Generator/ConfigurationClassGeneratorTest.php
+++ b/Tests/Unit/Generator/ConfigurationClassGeneratorTest.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Generator;

--- a/Tests/Unit/Mapper/TreeMapperFactoryTest.php
+++ b/Tests/Unit/Mapper/TreeMapperFactoryTest.php
@@ -3,21 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Mapper;

--- a/Tests/Unit/Parser/ExtConfTemplateParserTest.php
+++ b/Tests/Unit/Parser/ExtConfTemplateParserTest.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Parser;

--- a/Tests/Unit/Provider/TypedExtensionConfigurationProviderTest.php
+++ b/Tests/Unit/Provider/TypedExtensionConfigurationProviderTest.php
@@ -3,22 +3,16 @@
 declare(strict_types=1);
 
 /*
- * This file is part of the TYPO3 CMS extension "typed-extconf".
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 namespace mteu\TypedExtConf\Tests\Unit\Provider;

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -3,20 +3,14 @@
 /*
  * This file is part of the TYPO3 CMS extension "typed_extconf".
  *
- * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 2 of the License, or
- * (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ * The TYPO3 project - inspiring people to share!
  */
 
 /** @noinspection PhpUndefinedVariableInspection */

--- a/packaging_exclude.php
+++ b/packaging_exclude.php
@@ -2,6 +2,19 @@
 
 declare(strict_types=1);
 
+/*
+ * This file is part of the TYPO3 CMS extension "typed_extconf".
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
 return [
     'directories' => [
         '.idea',


### PR DESCRIPTION
With this PR, all GPL license headers are now rephrased to adhere to TYPO3's coding standards. The change in `php-cs-fixer.php` assures to update the license header automatically with `composer cgl fix`. Copyright information can still be added to class doc comments.