### PR TITLE
[BUGFIX] Make sure FQCNs are used in generated config classes

### DIFF
--- a/Classes/Generator/ConfigurationClassGenerator.php
+++ b/Classes/Generator/ConfigurationClassGenerator.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 
 namespace mteu\TypedExtConf\Generator;
 
+use mteu\TypedExtConf\Attribute\ExtConfProperty;
+use mteu\TypedExtConf\Attribute\ExtensionConfig;
 use Nette\PhpGenerator\PhpFile;
 use Nette\PhpGenerator\PsrPrinter;
 
@@ -43,14 +45,14 @@ final readonly class ConfigurationClassGenerator
         $file->setStrictTypes();
 
         $namespace = $file->addNamespace($this->generateNamespaceName($extensionKey));
-        $namespace->addUse('mteu\\TypedExtConf\\Attribute\\ExtConfProperty');
-        $namespace->addUse('mteu\\TypedExtConf\\Attribute\\ExtensionConfig');
+        $namespace->addUse(ExtConfProperty::class);
+        $namespace->addUse(ExtensionConfig::class);
 
         $class = $namespace->addClass($className);
         $class->setFinal(true);
         $class->setReadOnly(true);
         $class->setComment($this->generateClassDocumentation($className, $extensionKey));
-        $class->addAttribute('ExtensionConfig', ['extensionKey' => $extensionKey]);
+        $class->addAttribute(ExtensionConfig::class, ['extensionKey' => $extensionKey]);
 
         $constructor = $class->addMethod('__construct');
         $constructor->setPublic();
@@ -115,7 +117,7 @@ final readonly class ConfigurationClassGenerator
             $attributeArgs['required'] = true;
         }
 
-        $parameter->addAttribute('ExtConfProperty', $attributeArgs);
+        $parameter->addAttribute(ExtConfProperty::class, $attributeArgs);
     }
 
     private function formatDefaultValueForParameter(mixed $value, string $type): mixed

--- a/Tests/Unit/Generator/ConfigurationClassGeneratorTest.php
+++ b/Tests/Unit/Generator/ConfigurationClassGeneratorTest.php
@@ -76,12 +76,12 @@ final class ConfigurationClassGeneratorTest extends Framework\TestCase
 
         // Test class structure
         self::assertStringContainsString('final readonly class TestConfiguration', $result);
-        self::assertStringContainsString('#[\\ExtensionConfig(extensionKey: \'test_extension\')]', $result);
+        self::assertStringContainsString('#[ExtensionConfig(extensionKey: \'test_extension\')]', $result);
 
         // Test properties with PHP defaults (not in attributes)
-        self::assertStringContainsString('#[\\ExtConfProperty(path: \'api.key\', required: true)]', $result);
+        self::assertStringContainsString('#[ExtConfProperty(path: \'api.key\', required: true)]', $result);
         self::assertStringContainsString('public string $apiKey = \'default-key\',', $result);
-        self::assertStringContainsString('#[\\ExtConfProperty]', $result);
+        self::assertStringContainsString('#[ExtConfProperty]', $result);
         self::assertStringContainsString('public int $timeout = 30,', $result);
     }
 


### PR DESCRIPTION
The generated attributes were written as `#[\ExtConfProperty]` and `#[\ExtensionConfig]` where it should be `#[ExtConfProperty]` and `#[ExtensionConfig]` (no backslash, because classes are already imported in `use` section of the class). This PR fixes this behavior and the appropriate test cases (which were broken as well).