### PR TITLE
[BUGFIX] Assure `Configuration` folder is not excluded from packaging

### DIFF
--- a/packaging_exclude.php
+++ b/packaging_exclude.php
@@ -23,7 +23,6 @@ return [
         '.github',
         '.idea',
         'Tests',
-        'config',
         'tailor-version-artefact',
         'var',
     ],


### PR DESCRIPTION
The `Configuration` folder must not be excluded from packaging, otherwise core components of the extension won't work in classic mode. Since tailor does not treat configured directories in the `packaging_exclude.php` file as exact patterns, the configured `config` directory must be removed.